### PR TITLE
minor tweaks fo guice bindings

### DIFF
--- a/client/src/main/java/com/nesscomputing/service/discovery/client/DiscoveryClientModule.java
+++ b/client/src/main/java/com/nesscomputing/service/discovery/client/DiscoveryClientModule.java
@@ -83,9 +83,8 @@ public class DiscoveryClientModule extends AbstractModule
             bind(ReadOnlyDiscoveryClient.class).to(ReadOnlyDiscoveryClientImpl.class).in(Scopes.SINGLETON);
         }
         else {
-            bind(DiscoveryClientImpl.class).in(Scopes.SINGLETON);
-            bind(ReadOnlyDiscoveryClient.class).to(DiscoveryClientImpl.class).in(Scopes.SINGLETON);
             bind(DiscoveryClient.class).to(DiscoveryClientImpl.class).in(Scopes.SINGLETON);
+            bind(ReadOnlyDiscoveryClient.class).to(DiscoveryClient.class).in(Scopes.SINGLETON);
             bind(ServiceAnnouncer.class).asEagerSingleton();
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.nesscomputing</groupId>
     <artifactId>ness-oss-parent</artifactId>
-    <version>11</version>
+    <version>12</version>
   </parent>
 
   <scm>
@@ -60,7 +60,7 @@
       <dependency>
         <groupId>com.nesscomputing.components</groupId>
         <artifactId>ness-lifecycle</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
       </dependency>
 
       <dependency>
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>com.nesscomputing.components</groupId>
         <artifactId>ness-httpserver</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.2</version>
       </dependency>
 
       <dependency>
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>com.nesscomputing.components</groupId>
         <artifactId>ness-config</artifactId>
-        <version>2.1.3</version>
+        <version>2.2.0</version>
       </dependency>
 
       <dependency>
@@ -120,13 +120,13 @@
       <dependency>
         <groupId>com.nesscomputing.components</groupId>
         <artifactId>ness-jersey</artifactId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
       </dependency>
 
       <dependency>
         <groupId>com.nesscomputing.components</groupId>
         <artifactId>ness-jackson</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.3</version>
       </dependency>
 
       <dependency>

--- a/testing/src/main/java/com/nesscomputing/service/discovery/testing/server/MockedDiscoveryService.java
+++ b/testing/src/main/java/com/nesscomputing/service/discovery/testing/server/MockedDiscoveryService.java
@@ -49,12 +49,15 @@ public class MockedDiscoveryService implements MockedService {
     }
 
     @Override
-    public Map<String, String> getServiceConfigTweaks(String serviceName) {
+    public Map<String, String> getServiceConfigTweaks(final String serviceName) {
         return getTestCaseConfigTweaks();
     }
 
     @Override
     public Map<String, String> getTestCaseConfigTweaks() {
-        return ImmutableMap.of("ness.discovery.enabled", "true");
+        return ImmutableMap.of("ness.discovery.enabled", "true",
+                               "ness.zookeeper.clientPort", "0",
+                               "ness.zookeeper.clientPortAddress", "127.0.0.1"
+                               );
     }
 }


### PR DESCRIPTION
This allows easier overriding of the disco module (overriding the ReadOnlyDiscoveryClient binding is now sufficient). 

Also add a couple of config tweaks that are needed (but hidden by the current integration testing code using lazy initialization).
